### PR TITLE
Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# Debian based image with the lastest stable version of Rust.
+FROM rust:slim-bullseye AS multistage
+
+# The executable binary must be in the same folder as the Dockerfile.
+COPY faithful-servant-bot /opt/
+
+# Create a new container, which will be used to actually run the bot.
+FROM rust:slim-bullseye
+
+# Create the folder where the bot will run.
+RUN cd /opt && \
+        mkdir botdir
+
+# Copy from the initial container.
+COPY --from=multistage /opt/faithful-servant-bot /opt/botdir/
+
+# Make the file executale
+RUN chmod +x /opt/botdir/faithful-servant-bot
+
+# Add the user, chown folder.
+RUN useradd --no-log-init --shell /bin/false --no-create-home andrew-martin && \
+        chown -R andrew-martin:andrew-martin /opt/botdir
+
+# Change user, set workdir.
+USER andrew-martin
+WORKDIR /opt/botdir/
+
+# Start the bot.
+ENTRYPOINT ["./faithful-servant-bot"]


### PR DESCRIPTION
This pull request adds a very basic, minimal Docker image to the project. 

This image doesn't test, or compile the bot, instead, it copies an already existing, pre-compiled binary to a container, and works with that. Because of this, in order to build this image, a compiled executable named `faithful-servant-bot` has to be in the same directory as the Dockerfile. 

This Dockerfile is based on the `rust:slim-bullseye` image, as currently GitHub actions compiles using `ubuntu` which uses `gclib`.
It is possible to make this Alpine based, but that would require compiling with `musl`.

Data directory: `/opt/botdir`

When first running this image, it'll error out due to missing credentials in the config file. To fix this; 
1. Copy it out using `docker cp` (  `docker cp containername:/opt/botdir/config.ron /path/to/copy/to/.` ( `.` points to the current dir. )).
2. Edit the credentials, and copy it back using the same command. ( `docker cp config.ron containername:/opt/botdir/config.ron` )
3. Enjoy! :smile:

Possible features to add to this image include enviroment variables, or/and a mountable config file. 
- Enviroment variables: For as an example `-e IRC_<host | password | username | whatever>=<value>`, `-e POSTGRES_URL=<url>=<value>`
- Mountable config file: `-v /path/to/pre/defined/config.ron`

Feedback is very appriciated! 